### PR TITLE
Fix PlanetData.CalcVeinAmounts for DSP 0.9.27.15033

### DIFF
--- a/DSPSpreadsheetGenMod.cs
+++ b/DSPSpreadsheetGenMod.cs
@@ -717,7 +717,21 @@ namespace StarSectorResourceSpreadsheetGenerator
                 }
                 else
                 {
-                    planet.CalcVeinAmounts(ref veinAmounts);
+                    // Modify from PlanetData.CalcVeinAmounts
+                    Array.Clear(veinAmounts, 0, veinAmounts.Length);
+                    VeinGroup[] runtimeVeinGroups = planet.runtimeVeinGroups;
+                    if (runtimeVeinGroups != null)
+                    {
+                        lock (planet.veinGroupsLock)
+                        {
+                            for (int i = 1; i < runtimeVeinGroups.Length; i++)
+                            {
+                                veinAmounts[(int)runtimeVeinGroups[i].type] += runtimeVeinGroups[i].amount;
+                            }
+                        }
+                        veinAmounts[0] = 0L;
+                    }
+
                     EVeinType type = (EVeinType)1;
                     foreach (VeinProto item in LDB.veins.dataArray)
                     {


### PR DESCRIPTION
In DSP 0.9.27.15033, `PlanetData.CalcVeinAmounts(ref long[] veinAmounts)` has changed its declaring type to `CalcVeinAmounts(ref long[] veinAmounts, HashSet<int> hashes, int filterType)`, thus breaking the mod.
So I replace the part to make the mod more robust.